### PR TITLE
flash more than one npk during netinstall

### DIFF
--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -353,7 +353,6 @@ class Flasher:
         self.logger.debug("Done with the Firmware")
 
         # Send the initial config file. routerOS expects filename to be autorun.scr.
-        rsc = files[-1]
         if rsc:
             rsc_file, rsc_file_name, rsc_file_size = self.resolve_file_data(rsc)
             self.do(bytes(f"FILE\nautorun.scr\n{str(rsc_file_size)}\n", "utf-8"), b"RETR")

--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -158,7 +158,7 @@ class Flasher:
         Checks that the RouterOS file the plugin returned is valid to avoid
         formatting the Routerboard without being able to install an OS.
         """
-        npk, _ = self.plugin.get_files(info)
+        npk = self.plugin.get_files(info)[0]
         if npk is None:
             raise AbortFlashing("Verification failed: Plugin did not return RouterOS.")
 
@@ -237,7 +237,7 @@ class Flasher:
         self.do(b"FILE\n", b"WTRM")
         # Tell the board that it can now reboot and load the files
         self.logger.debug("Rebooting the Board")
-        self.do(b"TERM\nInstallation successful\n")
+        self.do(b"TERM\n")
 
         self.logger.info(f"{info.mac.hex(':')} was successfully flashed.")
         return
@@ -327,30 +327,31 @@ class Flasher:
             else:
                 # main reason why flashing is so slow but without this sleep state errors occur
                 time.sleep(0.005)
-        
+
     def do_files(self) -> None:
         """
         Sends the npk and the rsc file to the Connection using the do_files() Function
         It requests both files from the get_files() Function of the Plugin
         """
-        npk, rsc = self.plugin.get_files(self.info)
-        if npk is None:
-            raise AbortFlashing("Plugin did not return RouterOS.")
+        files = self.plugin.get_files(self.info)
+        for npk in files[:-1]:
+            # Send the .npk file
+            npk_file, npk_file_name, npk_file_size = self.resolve_file_data(npk)
+            try:
+                self.do(bytes(f"FILE\n{npk_file_name}\n{str(npk_file_size)}\n", "utf-8"), b"RETR")
+            except AbortFlashing:
+                # NOTE: it appears that not all devices send a 'RETR' response here, so we ignore it.
+                pass
+            self.logger.info(f"Uploading {npk_file_name}")
+            self.do_file(npk_file, npk_file_size, npk_file_name)
 
-        # Send the .npk file
-        npk_file, npk_file_name, npk_file_size = self.resolve_file_data(npk)
-        try:
-            self.do(bytes(f"FILE\n{npk_file_name}\n{str(npk_file_size)}\n", "utf-8"), b"RETR")
-        except AbortFlashing:
-            # NOTE: it appears that not all devices send a 'RETR' response here, so we ignore it.
-            pass
-        self.logger.info(f"Uploading {npk_file_name}")
-        self.do_file(npk_file, npk_file_size, npk_file_name)
+            # wait before sending the next file
+            self.do(b"", b"RETR")
 
-        self.do(b"", b"RETR")
         self.logger.debug("Done with the Firmware")
 
         # Send the initial config file. routerOS expects filename to be autorun.scr.
+        rsc = files[-1]
         if rsc:
             rsc_file, rsc_file_name, rsc_file_size = self.resolve_file_data(rsc)
             self.do(bytes(f"FILE\nautorun.scr\n{str(rsc_file_size)}\n", "utf-8"), b"RETR")

--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -158,7 +158,7 @@ class Flasher:
         Checks that the RouterOS file the plugin returned is valid to avoid
         formatting the Routerboard without being able to install an OS.
         """
-        npk = self.plugin.get_files(info)[0]
+        npk, *_ = self.plugin.get_files(info)
         if npk is None:
             raise AbortFlashing("Verification failed: Plugin did not return RouterOS.")
 

--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -333,8 +333,10 @@ class Flasher:
         Sends the npk and the rsc file to the Connection using the do_files() Function
         It requests both files from the get_files() Function of the Plugin
         """
-        files = self.plugin.get_files(self.info)
-        for npk in files[:-1]:
+        *npks, rsc = self.plugin.get_files(self.info)
+        if not all(npks):
+            raise AbortFlashing("Plugin did not return RouterOS or an additional package is 'None'.")
+        for npk in npks:
             # Send the .npk file
             npk_file, npk_file_name, npk_file_size = self.resolve_file_data(npk)
             try:


### PR DESCRIPTION
This makes it so the plugin can return an array for get_files.  All the files are considered to be npk, except the last file which is considered to be the configuration.