### PR TITLE
Repeat data from router in OFFR in order to kick off flash

### DIFF
--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -219,7 +219,7 @@ class Flasher:
         self.logger.debug("Sending the offer to flash")
         try:
             self.state = [0, 0]
-            self.do(b"OFFR\n\n", b"YACK\n")
+            self.do(f"OFFR\n{info.lic_key}\n\n\n\0".encode(), b"YACK\n")
         # Errno 101 Network is unreachable
         except OSError as e:
             raise AbortFlashing(f"Network error: {e}")


### PR DESCRIPTION
Trying to replicate the packets from the official netinstall binary, I found that data sent by the router needed to be included in the OFFR in order to kick off the flash process. I tested this on a RB 2011iLS. Not sure what this _"magic"_ data is but is consistent between boots. 
[req_offr.txt](https://github.com/user-attachments/files/20075242/req_offr.txt)
