### PR TITLE
Fix: TypeError in version comparison (map to tuple conversion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ with RouterOS.
 
 ## Usage
 
-`python -m pynetinstall [-c CONFIG] [-i INTERFACE] [-v]`
+`pynetinstall [-c CONFIG] [-i INTERFACE] [-v]`
 
 *-c CONFIG*: Path to the configuration file. Defaults to `/etc/pynetinstall.ini`.  
 *-i INTERFACE*: MAC address or name of network interface. Defaults to `eth0`.  

--- a/pynetinstall/__main__.py
+++ b/pynetinstall/__main__.py
@@ -10,38 +10,42 @@ from pynetinstall.flash import FlashInterface, FatalError, AbortFlashing
 
 signal.signal(signal.SIGTERM, lambda sig, _: sys.exit(0))
 
-parser = argparse.ArgumentParser(__package__)
-parser.add_argument("-c", "--config", default="/etc/pynetinstall.ini", help="set location of configuration file")
-parser.add_argument("-i", "--interface", default="eth0", help="MAC or name of ethernet interface (name supported on Linux only)")
-parser.add_argument("-l", "--logging", default=None, help="python logging configuration")
-parser.add_argument("-v", "--verbose", action="count", default=0, help="enable verbose output")
-parser.add_argument("-1", "--oneshot", action="store_true", help="exit after flashing once")
-args = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser(__package__)
+    parser.add_argument("-c", "--config", default="/etc/pynetinstall.ini", help="set location of configuration file")
+    parser.add_argument("-i", "--interface", default="eth0", help="MAC or name of ethernet interface (name supported on Linux only)")
+    parser.add_argument("-l", "--logging", default=None, help="python logging configuration")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="enable verbose output")
+    parser.add_argument("-1", "--oneshot", action="store_true", help="exit after flashing once")
+    args = parser.parse_args()
 
-# default to ERROR+WARNING, each -v increases the verbosity (INFO, DEBUG). must not set to NOTSET (0), or logger gets disabled.
-levels = sorted([e for e in logging._levelToName.keys() if e > 0], reverse=True)
-verbosity = levels[min(len(levels)-1, levels.index(logging.WARNING) + args.verbose)]
-if not args.logging:
-    args.logging = os.path.join(os.path.dirname(__file__), "logging.ini")
-logging.config.fileConfig(args.logging)
+    # default to ERROR+WARNING, each -v increases the verbosity (INFO, DEBUG). must not set to NOTSET (0), or logger gets disabled.
+    levels = sorted([e for e in logging._levelToName.keys() if e > 0], reverse=True)
+    verbosity = levels[min(len(levels)-1, levels.index(logging.WARNING) + args.verbose)]
+    if not args.logging:
+        args.logging = os.path.join(os.path.dirname(__file__), "logging.ini")
+    logging.config.fileConfig(args.logging)
 
-is_mac = re.fullmatch(r"([0-9a-f]{2}[:]?){6}", args.interface, re.I)
-argdict = {
-    'mac_address' if is_mac else 'interface_name': args.interface,
-    'config_file': args.config,
-    'log_level': verbosity,
-}
+    is_mac = re.fullmatch(r"([0-9a-f]{2}[:]?){6}", args.interface, re.I)
+    argdict = {
+        'mac_address' if is_mac else 'interface_name': args.interface,
+        'config_file': args.config,
+        'log_level': verbosity,
+    }
 
-try:
-    fl_dev = FlashInterface(**argdict)
+    try:
+        fl_dev = FlashInterface(**argdict)
 
-    if args.oneshot:
-        fl_dev.flash_once()
-    else:
-        fl_dev.flash_until_stopped()
-except FatalError as e:
-    parser.error(e)
-except AbortFlashing as e:
-    sys.exit(1)
-except KeyboardInterrupt as e:
-    sys.exit(130)
+        if args.oneshot:
+            fl_dev.flash_once()
+        else:
+            fl_dev.flash_until_stopped()
+    except FatalError as e:
+        parser.error(e)
+    except AbortFlashing as e:
+        sys.exit(1)
+    except KeyboardInterrupt as e:
+        sys.exit(130)
+
+if __name__ == "__main__":
+    main()

--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -173,7 +173,7 @@ class Flasher:
 
         # extract version number. release_type is lowercase ASCII letter 'a'=alpha, 'b'=beta, 'c'=candidate, 'f'=final, other values are plain uint8
         patch, release_type, minor, major = header[0x24:0x28]
-        if map(int, info.min_os.split(".")) > (major, minor, patch):
+        if tuple(map(int, info.min_os.split("."))) > (major, minor, patch):
             release = {97: 'alpha', 98: 'beta', 99: 'rc', 102: ''}.get(release_type, '<unknown release type>')
             raise AbortFlashing(f"Verification failed: Tried to install RouterOS {major}.{minor}.{release}{patch}, but device requires at least {info.min_os}.")
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     ],
     entry_points={
-        "console_scripts": ["pynetinstall = pynetinstall.__main__"]
+        "console_scripts": ["pynetinstall = pynetinstall.__main__:main"]
     }
 )


### PR DESCRIPTION
## Problem Description
Fix a TypeError that occurred during NPK version validation in Python 3 environments.

## Changes Made
- Converted map object to tuple before comparison in `pynetinstall/flash.py`
- Prevents "'>' not supported between instances of 'map' and 'tuple'" error

## Impact
- Eliminates crashes during version compatibility checks
- Ensures reliable firmware validation across different Python 3 versions

## 问题描述
修复Python 3中NPK版本比较时的TypeError。

## 修改内容
- 在pynetinstall/flash.py中将map对象转换为tuple进行比较
- 修复"> not supported between instances of 'map' and 'tuple'"错误

## 影响范围
- 消除版本兼容性检查时的崩溃
- 确保在不同Python 3版本中可靠地进行固件验证