### PR TITLE
Fix: Invalid script entry point in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ with RouterOS.
 
 ## Usage
 
-`python -m pynetinstall [-c CONFIG] [-i INTERFACE] [-v]`
+`pynetinstall [-c CONFIG] [-i INTERFACE] [-v]`
 
 *-c CONFIG*: Path to the configuration file. Defaults to `/etc/pynetinstall.ini`.  
 *-i INTERFACE*: MAC address or name of network interface. Defaults to `eth0`.  

--- a/pynetinstall/__main__.py
+++ b/pynetinstall/__main__.py
@@ -8,40 +8,44 @@ import logging.config
 
 from pynetinstall.flash import FlashInterface, FatalError, AbortFlashing
 
-signal.signal(signal.SIGTERM, lambda sig, _: sys.exit(0))
+def main():
+    signal.signal(signal.SIGTERM, lambda sig, _: sys.exit(0))
 
-parser = argparse.ArgumentParser(__package__)
-parser.add_argument("-c", "--config", default="/etc/pynetinstall.ini", help="set location of configuration file")
-parser.add_argument("-i", "--interface", default="eth0", help="MAC or name of ethernet interface (name supported on Linux only)")
-parser.add_argument("-l", "--logging", default=None, help="python logging configuration")
-parser.add_argument("-v", "--verbose", action="count", default=0, help="enable verbose output")
-parser.add_argument("-1", "--oneshot", action="store_true", help="exit after flashing once")
-args = parser.parse_args()
+    parser = argparse.ArgumentParser(__package__)
+    parser.add_argument("-c", "--config", default="/etc/pynetinstall.ini", help="set location of configuration file")
+    parser.add_argument("-i", "--interface", default="eth0", help="MAC or name of ethernet interface (name supported on Linux only)")
+    parser.add_argument("-l", "--logging", default=None, help="python logging configuration")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="enable verbose output")
+    parser.add_argument("-1", "--oneshot", action="store_true", help="exit after flashing once")
+    args = parser.parse_args()
 
-# default to ERROR+WARNING, each -v increases the verbosity (INFO, DEBUG). must not set to NOTSET (0), or logger gets disabled.
-levels = sorted([e for e in logging._levelToName.keys() if e > 0], reverse=True)
-verbosity = levels[min(len(levels)-1, levels.index(logging.WARNING) + args.verbose)]
-if not args.logging:
-    args.logging = os.path.join(os.path.dirname(__file__), "logging.ini")
-logging.config.fileConfig(args.logging)
+    # default to ERROR+WARNING, each -v increases the verbosity (INFO, DEBUG). must not set to NOTSET (0), or logger gets disabled.
+    levels = sorted([e for e in logging._levelToName.keys() if e > 0], reverse=True)
+    verbosity = levels[min(len(levels)-1, levels.index(logging.WARNING) + args.verbose)]
+    if not args.logging:
+        args.logging = os.path.join(os.path.dirname(__file__), "logging.ini")
+    logging.config.fileConfig(args.logging)
 
-is_mac = re.fullmatch(r"([0-9a-f]{2}[:]?){6}", args.interface, re.I)
-argdict = {
-    'mac_address' if is_mac else 'interface_name': args.interface,
-    'config_file': args.config,
-    'log_level': verbosity,
-}
+    is_mac = re.fullmatch(r"([0-9a-f]{2}[:]?){6}", args.interface, re.I)
+    argdict = {
+        'mac_address' if is_mac else 'interface_name': args.interface,
+        'config_file': args.config,
+        'log_level': verbosity,
+    }
 
-try:
-    fl_dev = FlashInterface(**argdict)
+    try:
+        fl_dev = FlashInterface(**argdict)
 
-    if args.oneshot:
-        fl_dev.flash_once()
-    else:
-        fl_dev.flash_until_stopped()
-except FatalError as e:
-    parser.error(e)
-except AbortFlashing as e:
-    sys.exit(1)
-except KeyboardInterrupt as e:
-    sys.exit(130)
+        if args.oneshot:
+            fl_dev.flash_once()
+        else:
+            fl_dev.flash_until_stopped()
+    except FatalError as e:
+        parser.error(e)
+    except AbortFlashing as e:
+        sys.exit(1)
+    except KeyboardInterrupt as e:
+        sys.exit(130)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     ],
     entry_points={
-        "console_scripts": ["pynetinstall = pynetinstall.__main__"]
+        "console_scripts": ["pynetinstall = pynetinstall.__main__:main"]
     }
 )


### PR DESCRIPTION
## Problem Description
Fix the invalid script entry point configuration in `setup.py` that caused installation issues when using pip.

## Changes Made
- Fixed `console_scripts` entry point in `setup.py` to correctly point to `pynetinstall.__main__:main`
- Encapsulated main execution logic into `main()` function in `pynetinstall/__main__.py`
- Updated README.md Usage section to reflect correct command line usage

## Impact
- Resolves "ERROR: Invalid script entry point..." installation error
- Users can now properly run pyNetinstall via `pynetinstall` command after pip installation
- Maintains backward compatibility with existing usage patterns


## 问题描述
修复setup.py中无效的脚本入口点配置，解决pip安装时的错误。

## 修改内容
- 修复setup.py中的console_scripts入口点，指向pynetinstall.__main__:main
- 在pynetinstall/__main__.py中添加main()函数封装执行逻辑
- 更新README.md中的Usage部分，反映正确的命令行用法

## 影响范围
- 解决"ERROR: Invalid script entry point..."安装错误
- 用户安装后可通过`pynetinstall`命令直接运行
- 保持向后兼容性