### PR TITLE
Implement configurable source IP binding for Linux/为 Linux 实现可配置的源 IP 地址绑定

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ with RouterOS.
 
 `pynetinstall [-c CONFIG] [-i INTERFACE] [-v]`
 
-*-c CONFIG*: Path to the configuration file. Defaults to `/etc/pynetinstall.ini`.  
-*-i INTERFACE*: MAC address or name of network interface. Defaults to `eth0`.  
-*-l LOGGING*: [Python logging configuration]. Defaults to stderr.  
-*-1*: Enable one-shot mode (exit after flashing once).  
-*-v*: Increase verbosity. Default is errors and warnings.  
+*-c CONFIG*: Path to the configuration file. Defaults to `/etc/pynetinstall.ini`.
+*-i INTERFACE*: MAC address or name of network interface. Defaults to `eth0`.
+*-l LOGGING*: [Python logging configuration]. Defaults to stderr.
+*-1*: Enable one-shot mode (exit after flashing once).
+*-v*: Increase verbosity. Default is errors and warnings.
 *-h*: Display help and exit.
 
 Inferring the MAC address though the interface name is only supported on Linux.
@@ -166,27 +166,41 @@ class Plugin:
 
         return firmware, configuration_or_None
 ```
+## **Binding Source IP Address (`bind_ip`)**
 
+For servers configured with multiple IP addresses on a single interface (e.g., a DHCP IP for 
+management and a static IP for Netinstall service), you can now specify the exact source IP 
+address pyNetinstall should use for its outgoing communication. This ensures devices correctly 
+receive replies after discovery.
+
+Add the `bind_ip` parameter to the `[pynetinstall]` section of your configuration file (`pynetinstall.ini`):
+
+```ini
+[pynetinstall]
+# Specify the source IP address for sending reply packets (Linux only)
+bind_ip = 10.10.10.1
+# ... other configurations ...
+```
 ## Extracting Boot Images
 
-You will need to aquire the boot images that the official netinstall tool uses.
+You will need to acquire the boot images that the official netinstall tool uses.
 These are not included as they are not licensed for re-distribution. However, it
 is fairly easy to extract them from the Mikrotik's Netinstall tool.
 
 **Note**: You must use at least the netinstall version that a device was shipped
 with. Check `/system routerboard print` -> `factory-firmware` if unsure.
 
-1. **Download `netinstall-<version>.zip` for Windows and extract it**  
+1. **Download `netinstall-<version>.zip` for Windows and extract it**
    The latest version that is linked in the [Downloads page] General section
    should work fine for all RouterOS versions. The [Download Archive] has links
    to older versions. <!-- for rOS 6.x no links are given, but the URLs follow
    the same schema as for 7.x. Both 32 and 64 bit versions should work. -->
 
-2. **Install the `pefile` and `pyelftools` Python packages**  
-   `pip install --user pefile pyelftools`  
+2. **Install the `pefile` and `pyelftools` Python packages**
+   `pip install --user pefile pyelftools`
 
-3. **Extract the images**  
-   `./docs/extract_bootimages.py netinstall64.exe`  
+3. **Extract the images**
+   `./docs/extract_bootimages.py netinstall64.exe`
    This will extract all images into the current directory.
 
 [Downloads page]: https://mikrotik.com/download

--- a/docs/routeros.md
+++ b/docs/routeros.md
@@ -55,6 +55,17 @@ Create `pynetinstall.ini` and upload it to the subdirectory. See the section
 [Using the default plugin]: ../README.md#using-the-default-plugin
 [Providing a custom plugin]: ../README.md#providing-a-custom-plugin
 
+#### **Network Interface Configuration Note**
+
+If your Linux host or Docker container interface is configured with multiple IP 
+addresses, you may need to utilize the `bind_ip` configuration option to force 
+pyNetinstall to use a specific local IP address for communication. This is crucial 
+to ensure PXE booting Mikrotik devices successfully receive the Netinstall service's 
+replies.
+
+Please refer to the main `README.md` for detailed instructions on using the `bind_ip` 
+parameter.
+
 
 ## Configure a Virtual Interface and Bridge
 

--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -45,11 +45,11 @@ class Flasher:
     state : list
         The current state of the flash (default: [0, 0])
     plugin : Plugin
-        A Plugin to get the firmware and the configuration file 
+        A Plugin to get the firmware and the configuration file
         (Must include a .get_files(), has the Configuration as an attribute)
     logger : Logger
         Object to log LogRecords
-    
+
     MAX_BYTES : int
         How many bytes the connection can receive at once (default: 1024)
 
@@ -72,10 +72,10 @@ class Flasher:
 
     do_file(file, max_pos, file_name) -> None
         Send a `file` over the Connection
-    
+
     do_files() -> None
         Get the files from the `plugin` and execute do_file() for every file
-    
+
     wait() -> None
         Wait for something
 
@@ -91,7 +91,7 @@ class Flasher:
                  logger: Logger = None) -> None:
         """
         Initialization of a new Flasher
-        
+
         Loading the Configuration
         Creating a Connection to the Interface
 
@@ -131,7 +131,7 @@ class Flasher:
         FileNotFoundError
             If the `config_file` does not exist or is not found
         """
-        
+
         cparser = ConfigParser()
         if not cparser.read(config_file):
             raise FatalError(f"Configuration File ({config_file}) not found")
@@ -182,12 +182,12 @@ class Flasher:
     def write(self, data: bytes) -> None:
         """
         Write the `data` to the UDPConnection
-        
+
         This function is used to pass the value of `state` to the write function of the connection.
 
         Arguments
         ---------
-        
+
         data : bytes
             The data you want to write to the connection as bytes
         """
@@ -196,8 +196,8 @@ class Flasher:
     def read(self) -> tuple[bytes, list]:
         """
         Read `data` from the UDPConnection
-        
-        This function is used to pass the value of `state` and `dev_mac` 
+
+        This function is used to pass the value of `state` and `dev_mac`
         to the read function of the connection.
 
         Returns
@@ -386,7 +386,7 @@ class Flasher:
         Returns
         -------
 
-         - BufferedReader or HTTPResponse: object with a .read() function 
+         - BufferedReader or HTTPResponse: object with a .read() function
          - str: The name of the file
          - int: The size of the file
 
@@ -472,8 +472,25 @@ class FlashInterface:
         """
         self.logger = Logger(log_level)
         self.config_file = config_file
+
+        # Read configuration file to get bind_ip parameter
+        bind_ip = None
         try:
-            self.connection = UDPConnection(logger=self.logger, interface_name=interface_name, mac_address=mac_address)
+            cparser = ConfigParser()
+            if cparser.read(config_file):
+                bind_ip = cparser.get("pynetinstall", "bind_ip", fallback=None)
+                if bind_ip:
+                    self.logger.debug(f"Using bind_ip: {bind_ip}")
+        except Exception as e:
+            self.logger.error(f"Failed to read bind_ip from config: {e}")
+
+        try:
+            self.connection = UDPConnection(
+                logger=self.logger,
+                interface_name=interface_name,
+                mac_address=mac_address,
+                bind_ip=bind_ip  # Pass bind_ip parameter
+            )
         except (OSError, ValueError) as e:
             raise FatalError(f"{e} ({interface_name or mac_address})")
 

--- a/pynetinstall/network.py
+++ b/pynetinstall/network.py
@@ -1,9 +1,20 @@
 import fcntl
 import socket
 import struct
+import sys
 
 from pynetinstall.log import Logger
 from pynetinstall.interface import InterfaceInfo
+
+# Defensively define IP_PKTINFO constant
+try:
+    IP_PKTINFO = socket.IP_PKTINFO  # Prefer definition from standard library
+except AttributeError:
+    IP_PKTINFO = 8  # Fallback: Linux kernel standard value
+
+# Platform detection - enable this feature only on Linux
+if not sys.platform.startswith('linux'):
+    IP_PKTINFO = None
 
 
 class UDPConnection(socket.socket):
@@ -30,7 +41,7 @@ class UDPConnection(socket.socket):
 
     _get_source_mac() -> None
         Get the `mac` Address of the Raspberry
-    
+
     read(state) -> tuple
         Read data from the Connection
 
@@ -43,7 +54,7 @@ class UDPConnection(socket.socket):
     mac: bytes
 
     def __init__(self, addr: tuple = ("0.0.0.0", 5000), interface_name: str = None, mac_address: str = None, error_repeat: int = 25, logger: Logger = None, timeout: int = 60,
-                 family: socket.AddressFamily or int = socket.AF_INET, kind: socket.SocketKind or int = socket.SOCK_DGRAM, *args, **kwargs) -> None:
+                 family: socket.AddressFamily or int = socket.AF_INET, kind: socket.SocketKind or int = socket.SOCK_DGRAM, bind_ip: str = None, *args, **kwargs) -> None:
         """
         Initialize a new UDPConnection
 
@@ -67,6 +78,8 @@ class UDPConnection(socket.socket):
             How often a function is repeated until it gets the right response or it raises an error (default: 25)
         timeout : int
             Time in seconds to wait for responses from devices before aborting (default: 60)
+        bind_ip : optional[str]
+            Specific IP address to use as source when sending replies (Linux only)
         """
         super().__init__(family, kind, *args, **kwargs)
         self.logger = logger
@@ -76,6 +89,21 @@ class UDPConnection(socket.socket):
         self.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         self.bind(addr)
         self.settimeout(timeout)
+
+        # Set bind_ip parameter to specify source IP for sending replies
+        self.bind_ip = bind_ip
+        if self.bind_ip and IP_PKTINFO is not None:
+            try:
+                # Enable IP_PKTINFO to get destination information and allow specifying source IP
+                self.setsockopt(socket.IPPROTO_IP, IP_PKTINFO, 1)
+                self.logger.debug(f"IP_PKTINFO enabled for source IP binding: {bind_ip}")
+            except Exception as e:
+                self.logger.error(f"Failed to set IP_PKTINFO: {e}. Source IP binding will not work.")
+                self.bind_ip = None
+        elif self.bind_ip:
+            self.logger.debug(f"Source IP binding requested but not supported on this platform: {bind_ip}")
+            self.bind_ip = None
+
         if interface_name:
             self.mac = self._get_source_mac(interface_name)
         elif mac_address:
@@ -110,7 +138,7 @@ class UDPConnection(socket.socket):
 
         Returns
         -------
-        
+
          - bytes: The data received from the Interface, or None on error
          - list: The State displayed in the Header of the UDPPacket, or None on error
         """
@@ -120,7 +148,7 @@ class UDPConnection(socket.socket):
 
         # since we listen for broadcasts, we also receive any packets we sent ourselves, so we have to filter out packets with our ip in src
         if addr[0] == "0.0.0.0": # Routerboard sets this as srcip
-            # The fist 6 bytes are the MAC Address of the source 
+            # The fist 6 bytes are the MAC Address of the source
             header_mac: bytes = data[:6]
             # From bytes 16 to 20 the states are displayed
             header_state: list[int] = [*struct.unpack("<HH", data[16:20])]
@@ -160,6 +188,26 @@ class UDPConnection(socket.socket):
         # 6. The State of the Client                (2 bytes)
         # 7. The data                               (? bytes)
         message = self.mac + dev_mac + struct.pack("<HHHH", 0, len(data), state[1], state[0]) + data
+
+        # If bind_ip is specified and platform supports it, use sendmsg to specify source IP
+        if self.bind_ip and IP_PKTINFO is not None:
+            try:
+                # Build control message for IP_PKTINFO
+                # struct in_pktinfo { ifindex, spec_dst, addr }
+                spec_dst = socket.inet_pton(socket.AF_INET, self.bind_ip)
+                ifindex = 0  # 0 means let kernel choose appropriate interface
+                # Format: I (4 bytes ifindex) + 4s (4 bytes spec_dst) + 4s (4 bytes addr, unused)
+                info = struct.pack('I4s4s', ifindex, spec_dst, b'\x00'*4)
+                ancdata = [(socket.IPPROTO_IP, IP_PKTINFO, info)]
+
+                # Send with control message to specify source IP
+                self.sendmsg([message], ancdata, 0, recv_addr)
+                return
+            except Exception as e:
+                self.logger.error(f"Failed to send with bind_ip {self.bind_ip}: {e}. Falling back to normal send.")
+                # Fall through to normal sendto
+
+        # Default behavior: use system-selected source IP
         self.sendto(message, recv_addr)
 
     def get_interface_info(self) -> InterfaceInfo:
@@ -181,7 +229,7 @@ class UDPConnection(socket.socket):
 
          - InterfaceInfo: A object with all the information of the Interface
         """
-        
+
         self.logger.debug("Searching for a Interface...")
         try:
             data, addr = self.recvfrom(self.MAX_BYTES_RECV)


### PR DESCRIPTION
### Problem Description  
On Linux servers with multiple IP addresses assigned to the same network interface (e.g., a management IP and a dedicated Netinstall service IP), pyNetinstall uses the system’s default source IP when sending reply packets. This can cause Netinstall devices to not receive replies if the default IP is not reachable from their network.

### Changes Made  
- Added a `bind_ip` configuration option in the `[pynetinstall]` section of the config file.  
- In `flash.py`, the value is read and passed to `UDPConnection`.  
- In `network.py`, when `bind_ip` is set on Linux, the socket enables `IP_PKTINFO` and uses `sendmsg()` with a control message to explicitly set the source IP address for each outgoing packet.  
- Implemented graceful fallback: on non-Linux platforms or if `IP_PKTINFO` is unavailable, the feature is disabled and normal `sendto()` is used, with appropriate logging.  
- Updated `README.md` and `docs/routeros.md` with usage instructions and a network configuration note.

### Impact  
- Users can now force pyNetinstall to use a specific source IP address on Linux, ensuring that reply packets reach the Netinstall devices correctly in multi-IP environments.  
- Fully backward compatible: if `bind_ip` is not specified, behavior remains unchanged.  
- Non‑Linux platforms are unaffected.  
- Includes defensive error handling to prevent crashes.


### 问题描述  
在拥有多个 IP 地址绑定到同一网络接口的 Linux 服务器上（例如一个管理 IP 和一个专用于 Netinstall 服务的 IP），pyNetinstall 发送应答包时使用系统的默认源 IP。如果默认 IP 在 Netinstall 设备所处的网络中不可达，会导致设备无法收到应答。

### 修改内容  
- 在配置文件的 `[pynetinstall]` 段中添加 `bind_ip` 配置项。  
- 在 `flash.py` 中读取该值并传递给 `UDPConnection`。  
- 在 `network.py` 中，当在 Linux 下设置了 `bind_ip` 时，启用 `IP_PKTINFO` socket 选项，并使用 `sendmsg()` 配合控制消息显式设置每个出站包的源 IP 地址。  
- 实现优雅降级：在非 Linux 平台或 `IP_PKTINFO` 不可用时，禁用该功能并使用普通的 `sendto()`，同时输出相应日志。  
- 更新 `README.md` 和 `docs/routeros.md`，添加使用说明和网络配置注意事项。

### 影响范围  
- 用户现在可以在 Linux 上强制 pyNetinstall 使用特定的源 IP 地址，确保在多 IP 环境中应答包能正确到达 Netinstall 设备。  
- 完全向后兼容：如果不指定 `bind_ip`，行为与之前完全一致。  
- 非 Linux 平台不受影响。  
- 包含防御性错误处理，防止崩溃。