### PR TITLE
add support to set device-mode during flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ tftp-no-blocksize
 pyNetinstall includes a simple plugin that serves a single firmware and
 optionally a single configuration file.
 
-The default plugin reads the `firmware` and `config` parameters from
+The default plugin reads the `firmware`, `config` and `device_mode` parameters from
 `pynetinstall.ini`. To disable uploading a config file and use MikroTik's
 default config instead, just remove the line from `pynetinstall.ini`. To not
 upload any config at all (and configure the device through MAC-Telnet/MAC-Winbox
@@ -107,6 +107,7 @@ Additional packages can be specified one per line, each indented by some spaces.
 [pynetinstall]
 firmware=<PATH_TO_ROUTEROS_NPK>
 config=<PATH_TO_CONFIG_RSC>
+device_mode=<PATH_TO_MODE_RSC>
 additional_packages=
     <ADDITIONAL_PACKAGE>
     <ADDITIONAL_PACKAGE>
@@ -131,12 +132,12 @@ plugin=<PYTHON_MODULE>:<CLASS_NAME>
 ```
 
 Such a plugin is simply a python class that implements `get_files(info)`,
-returning a tuple (firmware, config). Firmware and config may be returned as a
+returning a tuple (firmware, config, device_mode_script). Firmware and config may be returned as a
 path on disk (string), an HTTP  or HTTPS URL (string), or a [file object] as
 returned by e.g. `open()`.
 
 Additionally, config may be `None` if no custom default configuration is
-desired. If firmware is `None`, an error is assumed and the current flashing
+desired. The same applies to the device mode script if changing the mode is not desired. If firmware is `None`, an error is assumed and the current flashing
 process is aborted and pyNetinstall resets for the next flashing cycle.
 
 `get_files()` is passed an InterfaceInfo object, which contains information on
@@ -164,7 +165,7 @@ class Plugin:
         # info.lic_id       = installed license id
         # info.lic_key      = installed license key
 
-        return firmware, configuration_or_None
+        return firmware, configuration_or_None, modescript_or_None
 ```
 
 ## Extracting Boot Images
@@ -191,6 +192,10 @@ with. Check `/system routerboard print` -> `factory-firmware` if unsure.
 
 [Downloads page]: https://mikrotik.com/download
 [Download Archive]: https://mikrotik.com/download/archive
+
+## Notes about device-mode
+
+Boot images and RouterOS packages must be at least version 7.22 or higher in order to set device-mode.
 
 ## Acknowledgements
 

--- a/pynetinstall/flash.py
+++ b/pynetinstall/flash.py
@@ -344,7 +344,7 @@ class Flasher:
         Sends the npk and the rsc file to the Connection using the do_files() Function
         It requests both files from the get_files() Function of the Plugin
         """
-        *npks, rsc = self.plugin.get_files(self.info)
+        *npks, rsc, device_mode = self.plugin.get_files(self.info)
         if not all(npks):
             raise AbortFlashing("Plugin did not return RouterOS or an additional package is 'None'.")
         for npk in npks:
@@ -372,6 +372,18 @@ class Flasher:
 
             self.do(b"", b"RETR")
             self.logger.debug("Done with the Configuration File")
+    
+        # Send the device mode file if available. This file is used to set the device mode and is optional.
+        if device_mode:
+            device_mode_file, device_mode_file_name, device_mode_file_size = self.resolve_file_data(device_mode)
+            self.do(bytes(f"FILE\nmode.scr\n{str(device_mode_file_size)}\n", "utf-8"), b"RETR")
+            self.logger.info(f"Uploading {device_mode_file_name}")
+            self.do_file(device_mode_file, device_mode_file_size, device_mode_file_name)
+
+            self.do(b"", b"RETR")
+            self.logger.debug("Done with the device mode File")
+
+        
 
     def resolve_file_data(self, data) -> tuple[BufferedReader or HTTPResponse, str, int]:
         """

--- a/pynetinstall/plugins/simple.py
+++ b/pynetinstall/plugins/simple.py
@@ -36,6 +36,7 @@ class Plugin:
     def __init__(self, config: ConfigParser):
         self.firmware = config.get("pynetinstall", "firmware", fallback=None)
         self.default_config = config.get("pynetinstall", "config", fallback=None)
+        self.device_mode_script = config.get("pynetinstall", "device_mode", fallback=None)
         additional_packages = config.get("pynetinstall", "additional_packages", fallback="")
 
         if not self.firmware:
@@ -44,6 +45,8 @@ class Plugin:
             raise ValueError(f"The firmware file {self.firmware!r} does not exist")
         if self.default_config and not os.path.exists(self.default_config):
             raise ValueError(f"The config file {self.default_config!r} does not exist")
+        if self.device_mode_script and not os.path.exists(self.device_mode_script):
+            raise ValueError(f"The device mode script {self.device_mode_script!r} does not exist")
         self.additional_packages = additional_packages.splitlines()
         for pkg in self.additional_packages:
             if not os.path.exists(pkg):
@@ -66,4 +69,4 @@ class Plugin:
            If firmware is None, an error is assumed. If config is None, only
            the firmware will be installed.
         """
-        return self.firmware, *self.additional_packages, self.default_config
+        return self.firmware, *self.additional_packages, self.default_config, self.device_mode_script


### PR DESCRIPTION
Hi, 
I followed the approach outlined in #21 and added support for setting the device-mode during netinstall with the feature introduced in RouterOS 7.22. It appears it was as simple as sending an additional file with the name `mode.scr` containing the appropriate mode script. My test setting the mode on a wAP ac were successful.